### PR TITLE
BUG: Baseline methods' recommendations do not change in different queries - baseline_llm

### DIFF
--- a/backend/app/dataService/dataService.py
+++ b/backend/app/dataService/dataService.py
@@ -400,7 +400,10 @@ class DataService(object):
         # print('table_name_list',table_name_list)
         # print('table_name_list.keys',table_name_list.keys())
 
-        index=list(table_name_list.keys()).index(C_table_name)
+        normalized_table_name = C_table_name.replace('_', ' ').lower()
+        # print('normalized_table_name',normalized_table_name)
+
+        index=list(table_name_list.keys()).index(normalized_table_name)
         #index = vis['df_index']
         # print('index',index)
         #C_vis_obj = vis['vis_obj']


### PR DESCRIPTION
## Related Issue
Fixes: #5 

## What's Changed

- Before searching for the index, unify the data format between `C_table_name` and `table_name_list.keys()`, as shown in **line 403** of `backend/app/dataService/dataService.py`.
```Python
normalized_table_name = C_table_name.replace('_', ' ').lower()
# print('normalized_table_name',normalized_table_name)
index=list(table_name_list.keys()).index(normalized_table_name)
```

## How to Test
The original code already includes tests. Simply comment out the `exit()` on **line 668** in the updated code and execute the following command to run the tests.
```
python dataService.py
```

## What caused this Error

- `C_table_name` may return names with underscores (e.g. **'customer_addresses'**)
- And the names in `table_name_list.keys()` are with spaces and are all in lowercase (e.g. **'customer addresses'**)

## Verify the Output

### First Round Recommendations
1. `SELECT order_id FROM order_items`
2. `SELECT order_quantity FROM order_items` 
3. ✅`SELECT customer_id FROM customer_contact_channels` *(selected by user)*
4. `SELECT address_id FROM customer_addresses` 
5. `SELECT channel_code FROM customer_contact_channels`

### Second Round Recommendations (after selecting)
1. `SELECT order_id FROM order_items` *(kept from first round)*
2. `SELECT order_quantity FROM order_items` *(kept from first round)*
3. ➡️ `SELECT address_id FROM customer_addresses` *(promoted from position 4 to 3)*
4. ➕ `SELECT product_id FROM order_items` *(new addition)*
5. ➕ `SELECT address_type FROM customer_addresses` *(new address-related suggestion)*