### PR TITLE
BUG: Baseline methods' recommendations do not change in different queries - baseline_llm

### DIFF
--- a/backend/app/dataService/sqlParser.py
+++ b/backend/app/dataService/sqlParser.py
@@ -3,6 +3,7 @@ import sys
 import nltk
 nltk.download('punkt')
 nltk.download('stopwords')
+nltk.download('punkt_tab')
 import pathlib
 import numpy as np
 

--- a/backend/app/dataService/sqlmodel.py
+++ b/backend/app/dataService/sqlmodel.py
@@ -99,7 +99,7 @@ class sqlModel(object):
         res = db_chain.run(q)
         cleaned_res = clean_sql(res)
         # remove limit clause
-        res_ = remove_sql_clause(res, "LIMIT")
+        res_ = remove_sql_clause(cleaned_res, "LIMIT")
         return res_
 
     def sql2text(self, sql: str = "SELECT name ,  country ,  age FROM singer ORDER BY age DESC"):

--- a/backend/app/dataService/sqlmodel.py
+++ b/backend/app/dataService/sqlmodel.py
@@ -1,4 +1,5 @@
 from sqlalchemy import create_engine
+from utils.processSQL.clean_sql import clean_sql
 from langchain.sql_database import SQLDatabase
 import os, json, re
 from langchain_experimental.sql import SQLDatabaseChain
@@ -67,6 +68,8 @@ SQLQuery: SQL Query to run
 SQLResult: Result of the SQLQuery
 Answer: Final answer here
 
+IMPORTANT: After the 'SQLQuery:' tag, only provide the SQL code and nothing else. Do not add any explanations, notes, or comments.
+
 """
 
 PROMPT = PromptTemplate(
@@ -94,6 +97,7 @@ class sqlModel(object):
                           prompt=PROMPT
                          )
         res = db_chain.run(q)
+        cleaned_res = clean_sql(res)
         # remove limit clause
         res_ = remove_sql_clause(res, "LIMIT")
         return res_
@@ -101,6 +105,8 @@ class sqlModel(object):
     def sql2text(self, sql: str = "SELECT name ,  country ,  age FROM singer ORDER BY age DESC"):
         sql2text_prompt = """
         Please translate the following sql query into natural language to users who do not have sql knowledge and keep it simple. Please only output the natural language result.
+
+        IMPORTANT: Your response MUST be ONLY the translated natural language sentence. Do NOT include any introductory phrases like "This query retrieves..." or "The natural language translation is:".
 
         {sql}
 

--- a/backend/app/dataService/utils/processSQL/clean_sql.py
+++ b/backend/app/dataService/utils/processSQL/clean_sql.py
@@ -1,0 +1,111 @@
+import re
+
+# A list of SQL keywords.
+# It is sorted by length in descending order. This is a crucial step to ensure
+# that longer, multi-word keywords (e.g., 'GROUP BY') are matched before their
+# shorter counterparts (e.g., 'BY'), preventing incorrect tokenization.
+SQL_KEYWORDS = sorted([
+    # Composite Keywords (highest priority)
+    'GROUP BY', 'ORDER BY', 'PARTITION BY',
+    'LEFT JOIN', 'RIGHT JOIN', 'INNER JOIN', 'FULL OUTER JOIN',
+    'UNION ALL', 'INSERT INTO', 'DELETE FROM', 'CREATE TABLE',
+    'PRIMARY KEY',
+
+    # Single Long Keywords
+    'INTERSECT', 'DISTINCT', 'BETWEEN', 'EXISTS',
+    'SELECT', 'WHERE', 'HAVING', 'UPDATE', 'VALUES',
+    'EXCEPT', 'LIMIT', 'OFFSET',
+
+    # Aggregate/Window Functions & Sorting
+    'COUNT', 'SUM', 'AVG', 'MIN', 'MAX',
+    'DESC', 'ASC', 'OVER',
+
+    # Logical, Join, Alias, and Comparison Operators
+    'FROM', 'JOIN', 'LIKE', 'AND', 'NOT',
+    'AS', 'ON', 'OR', 'IN', 'IS'
+
+], key=len, reverse=True)
+
+
+def clean_sql(sql: str) -> str:
+    """
+    Cleans and standardizes a raw SQL query string.
+
+    This function performs several normalization steps:
+    1. Removes common markdown code fences (e.g., ```sql).
+    2. Removes double quotes and trailing semicolons.
+    3. Converts all defined SQL keywords to uppercase.
+    4. Keep column and table names in lowercase
+    5. Standardizes all whitespace to single spaces.
+
+    Args:
+        sql (str): The raw SQL string to be cleaned.
+
+    Returns:
+        str: The cleaned and formatted SQL string, or the original input
+             if it's not a string.
+    """
+    # Guard clause to handle non-string inputs gracefully.
+    if not isinstance(sql, str):
+        return sql
+
+    # 1. Remove optional markdown code fences and trim leading/trailing whitespace.
+    cleaned_sql = re.sub(r'^```sql\s*|\s*```$', '', sql, flags=re.IGNORECASE).strip()
+
+    # 2. Remove all double quotes, often used for identifiers but can be inconsistent.
+    cleaned_sql = cleaned_sql.replace('"', '')
+
+    # 3. Remove a trailing semicolon, if present.
+    if cleaned_sql.endswith(';'):
+        cleaned_sql = cleaned_sql[:-1]
+
+    # 4. Build a regex pattern to match all keywords as whole words.
+    # The `\b` word boundaries prevent matching substrings within other words
+    # (e.g., it won't match 'OR' in 'BORDER').
+    keyword_pattern = '|'.join(r'\b' + re.escape(k) + r'\b' for k in SQL_KEYWORDS)
+
+    # 5. Convert the entire query to lowercase to ensure case-insensitive matching.
+    sql_lower = cleaned_sql.lower()
+
+    # 6. Use a helper function with re.sub to find all keyword matches and
+    # convert only those matched parts to uppercase.
+    def uppercase_match(match):
+        return match.group(0).upper()
+
+    cleaned_sql = re.sub(keyword_pattern, uppercase_match, sql_lower, flags=re.IGNORECASE)
+
+    # 7. Normalize all whitespace (multiple spaces, newlines, etc.) to a single space.
+    final_sql = re.sub(r'\s+', ' ', cleaned_sql).strip()
+
+    return final_sql
+
+
+# Main execution block for demonstration and testing purposes.
+if __name__ == '__main__':
+    # Define a simple sample SQL query for testing.
+    input_sql = '   SELECT customer_name, other_customer_details FROM "Customers" ORDER BY customer_id;   '
+
+    # Call the cleanup function.
+    cleaned_sql = clean_sql(input_sql)
+
+    # Print the original and cleaned versions to compare.
+    print(f"Original SQL: {input_sql}")
+    print(f"Cleaned SQL:  {cleaned_sql}")
+
+    # Define a more complex query to showcase multiple features of the cleaner.
+    complex_sql_example = """
+    ```sql
+    select
+        user_id,
+        COUNT(order_id) as order_count,
+        max(order_date)
+    from "orders_table"
+    where order_date >= '2023-01-01' and not is_cancelled
+    group by user_id
+    having count(order_id) > 5
+    order by order_count desc;
+    ```
+    """
+    print("--- Complex Example ---")
+    print(f"Original SQL:\n{complex_sql_example.strip()}")
+    print(f"Cleaned SQL:\n{clean_sql(complex_sql_example)}")


### PR DESCRIPTION
## Related Issue
Fixes: #6 #13  
This is a summary of all the issues in the `Baseline-llm branch` to make the system stable and robust.

## What's Changed
1. Added `nltk.download('punkt_tab')` to `sqlParser.py`.
2. Optimized the prompt to improve model output in `sqlmodel.py`.
- In the Text-to-SQL prompt (_DEFAULT_TEMPLATE), the following instruction was added:
```
IMPORTANT: After the 'SQLQuery:' tag, only provide the SQL code and nothing else. Do not add any explanations, notes, or comments.
```
- In the SQL-to-Text prompt (sql2text_prompt), this instruction was added to ensure only the translated sentence is returned:
```
IMPORTANT: Your response MUST be ONLY the translated natural language sentence. Do NOT include any introductory phrases like "This query retrieves..." or "The natural language translation is:".
```
3. Implemented a more thorough SQL cleanup process in `utils/processSQL/clean_sql.py`.

## How to Test

1.  **SQL Cleanup:** Test the cleaning script directly by running `utils/processSQL/clean_sql.py`.
2.  **Overall System:** Verify the combined results of the prompt and cleanup enhancements by running the full `baseline-llm` system and observing its output.

## What caused the Errors

1.  **Incorrect Parsing of Table Names with Underscores**
 Regarding the issues mentioned in the previous PR, the root cause was a missing `nltk.download('punkt_tab')` call in `sqlParser.py`. This caused the `try` block in the `sql2vis` function to fail, as its parser (`self.parsesql`) depends on this NLTK resource. Consequently, the program fell back to the `except` block, which contained a simpler parser that did not handle underscores in table names, leading to the error.
**Note:** The `nltk.download('punkt_tab')` call was present in the `llm` branch but was missing from the `baseline-llm` branch, which explains the discrepancy.

2.  **LLM Output Formatting Issues**
The model was generating improperly formatted SQL, which caused parsing failures. **For instance**, it would sometimes add double quotes around table names (e.g., producing `"Customers"` instead of `customers`). This type of formatting error caused our SQL parser to fail, leading to a `List Index out of range` error.
**Note:**The problem of uncontrollable LLM output exists under both baseline-llm branch and llm branch


